### PR TITLE
Initial modem generic interface

### DIFF
--- a/src/modules/Modem/Modem.h
+++ b/src/modules/Modem/Modem.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "ModemBackend.h"
+
+enum ModemType { EG915U, SIM7080 };
+
+/* Modem is just an interface which on creation*/
+class Modem {
+ private:
+  ModemBackend *backend = nullptr;
+  ModemType Type;
+
+ public:
+  Modem(ModemType type) {
+    switch (type) {
+      case EG915U:
+        backend = new EG915ModemBackend();
+        break;
+      case SIM7080:
+        // backend = new SIM7080ModemBackend();
+        break;
+    }
+    Type = type;
+  }
+
+  ModemType getType() const { return Type; }
+  void setType(ModemType t) { Type = t; }
+
+  bool init(Stream &stream, AsyncATHandler &atHandler, GSMTransport &transport) {
+    return backend->init(stream, atHandler, transport);
+  }
+  bool setEchoOff() { return backend->setEchoOff(); }
+  bool enableVerboseErrors() { return backend->enableVerboseErrors(); }
+  bool checkModemModel() { return backend->checkModemModel(); }
+  bool checkTimezone() { return backend->checkTimezone(); }
+  bool checkSIMReady() { return backend->checkSIMReady(); }
+  bool disalbeSleepMode() { return backend->disalbeSleepMode(); }
+  bool gprsConnect(const char *apn, const char *user = nullptr, const char *pass = nullptr) {
+    return backend->gprsConnect(apn, user, pass);
+  }
+  bool gprsDisconnect() { return backend->gprsDisconnect(); }
+  String getSimCCID() { return backend->getSimCCID(); }
+  String getIMEI() { return backend->getIMEI(); }
+  String getIMSI() { return backend->getIMSI(); }
+  String getOperator() { return backend->getOperator(); }
+  String getIPAddress() { return backend->getIPAddress(); }
+  bool connect(const char *host, uint16_t port) { return backend->connect(host, port); }
+  bool stop() { return backend->stop(); }
+  bool connectSecure(const char *host, uint16_t port) { return backend->connectSecure(host, port); }
+  bool connectSecure(const char *host, uint16_t port, const char *caCertPath) {
+    return backend->connectSecure(host, port, caCertPath);
+  }
+  bool stopSecure() { return backend->stopSecure(); }
+  bool setSIMSlot(SimSlot slot) { return backend->setSIMSlot(slot); }
+
+  bool uploadUFSFile(
+      const char *path, const uint8_t *data, size_t size, uint32_t timeoutMs = 120000) {
+    return backend->uploadUFSFile(path, data, size, timeoutMs);
+  }
+  bool setCACertificate(const char *ufsPath, const char *ssl_cidx) {
+    return backend->setCACertificate(ufsPath, ssl_cidx);
+  }
+  bool findUFSFile(const char *pattern, String *outName = nullptr, size_t *outSize = nullptr) {
+    return backend->findUFSFile(pattern, outName, outSize);
+  }
+
+  // Helpers for GPRS connection
+  void disableConnections() { backend->disableConnections(); }
+  bool setPDPContext(const char *apn) { return backend->setPDPContext(apn); }
+  bool activatePDPContext() { return backend->activatePDPContext(); }
+  bool isGPRSSAttached() { return backend->isGPRSSAttached(); }
+  bool checkNetworkContext() { return backend->checkNetworkContext(); }
+  bool activatePDP() { return backend->activatePDP(); }
+  bool attachGPRS() { return backend->attachGPRS(); }
+};

--- a/src/modules/Modem/Modem.h
+++ b/src/modules/Modem/Modem.h
@@ -7,13 +7,13 @@ enum ModemType { EG915U, SIM7080 };
 /* Modem is just an interface which on creation*/
 class Modem {
  private:
-  ModemBackend* backend = nullptr;
+  std::unique_ptr<ModemBackend> backend = nullptr;
 
  public:
   Modem(ModemType type) {
     switch (type) {
       case EG915U:
-        backend = new EG915ModemBackend();
+        backend = std::make_unique<EG915ModemBackend>();
         break;
       case SIM7080:
         // backend = new SIM7080ModemBackend();
@@ -21,5 +21,5 @@ class Modem {
     }
   }
 
-  ModemBackend* operator->() { return backend; }
+  ModemBackend* operator->() { return backend.get(); }
 };

--- a/src/modules/Modem/Modem.h
+++ b/src/modules/Modem/Modem.h
@@ -7,8 +7,7 @@ enum ModemType { EG915U, SIM7080 };
 /* Modem is just an interface which on creation*/
 class Modem {
  private:
-  ModemBackend *backend = nullptr;
-  ModemType Type;
+  ModemBackend* backend = nullptr;
 
  public:
   Modem(ModemType type) {
@@ -20,56 +19,7 @@ class Modem {
         // backend = new SIM7080ModemBackend();
         break;
     }
-    Type = type;
   }
 
-  ModemType getType() const { return Type; }
-  void setType(ModemType t) { Type = t; }
-
-  bool init(Stream &stream, AsyncATHandler &atHandler, GSMTransport &transport) {
-    return backend->init(stream, atHandler, transport);
-  }
-  bool setEchoOff() { return backend->setEchoOff(); }
-  bool enableVerboseErrors() { return backend->enableVerboseErrors(); }
-  bool checkModemModel() { return backend->checkModemModel(); }
-  bool checkTimezone() { return backend->checkTimezone(); }
-  bool checkSIMReady() { return backend->checkSIMReady(); }
-  bool disalbeSleepMode() { return backend->disalbeSleepMode(); }
-  bool gprsConnect(const char *apn, const char *user = nullptr, const char *pass = nullptr) {
-    return backend->gprsConnect(apn, user, pass);
-  }
-  bool gprsDisconnect() { return backend->gprsDisconnect(); }
-  String getSimCCID() { return backend->getSimCCID(); }
-  String getIMEI() { return backend->getIMEI(); }
-  String getIMSI() { return backend->getIMSI(); }
-  String getOperator() { return backend->getOperator(); }
-  String getIPAddress() { return backend->getIPAddress(); }
-  bool connect(const char *host, uint16_t port) { return backend->connect(host, port); }
-  bool stop() { return backend->stop(); }
-  bool connectSecure(const char *host, uint16_t port) { return backend->connectSecure(host, port); }
-  bool connectSecure(const char *host, uint16_t port, const char *caCertPath) {
-    return backend->connectSecure(host, port, caCertPath);
-  }
-  bool stopSecure() { return backend->stopSecure(); }
-  bool setSIMSlot(SimSlot slot) { return backend->setSIMSlot(slot); }
-
-  bool uploadUFSFile(
-      const char *path, const uint8_t *data, size_t size, uint32_t timeoutMs = 120000) {
-    return backend->uploadUFSFile(path, data, size, timeoutMs);
-  }
-  bool setCACertificate(const char *ufsPath, const char *ssl_cidx) {
-    return backend->setCACertificate(ufsPath, ssl_cidx);
-  }
-  bool findUFSFile(const char *pattern, String *outName = nullptr, size_t *outSize = nullptr) {
-    return backend->findUFSFile(pattern, outName, outSize);
-  }
-
-  // Helpers for GPRS connection
-  void disableConnections() { backend->disableConnections(); }
-  bool setPDPContext(const char *apn) { return backend->setPDPContext(apn); }
-  bool activatePDPContext() { return backend->activatePDPContext(); }
-  bool isGPRSSAttached() { return backend->isGPRSSAttached(); }
-  bool checkNetworkContext() { return backend->checkNetworkContext(); }
-  bool activatePDP() { return backend->activatePDP(); }
-  bool attachGPRS() { return backend->attachGPRS(); }
+  ModemBackend* operator->() { return backend; }
 };

--- a/src/modules/Modem/Modem.settings.h
+++ b/src/modules/Modem/Modem.settings.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <atomic>
+
+enum class RegStatus {
+  REG_NO_RESULT = -1,
+  REG_UNREGISTERED = 0,
+  REG_SEARCHING = 2,
+  REG_DENIED = 3,
+  REG_OK_HOME = 1,
+  REG_OK_ROAMING = 5,
+  REG_UNKNOWN = 4,
+};
+
+enum class ConnectionStatus {
+  DISCONNECTED,
+  FAILED,
+  CONNECTED,
+  CLOSING,
+};
+
+enum class MqttConnectionState {
+  IDLE,
+  DISCONNECTED,
+  CONNECTED,
+};
+
+struct UrcState {
+  std::atomic<RegStatus> creg{RegStatus::REG_NO_RESULT};
+  std::atomic<ConnectionStatus> isConnected{ConnectionStatus::DISCONNECTED};
+  std::atomic<MqttConnectionState> mqttState{MqttConnectionState::IDLE};
+};

--- a/src/modules/Modem/ModemBackend.h
+++ b/src/modules/Modem/ModemBackend.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <Arduino.h>
+#include <AsyncATHandler.h>
+#include <Stream.h>
+#include <utils/MqttQueue/MqttQueue.h>
+
+#include "Modem.settings.h"
+#include "SIMCard/SIMCard.h"
+#include "SIMCard/SIMCard.settings.h"
+
+class GSMTransport;
+
+class ModemBackend {
+ private:
+  Stream *_stream = nullptr;
+  GSMTransport *transport = nullptr;
+  AsyncATHandler *at = nullptr;
+  bool certConfigured = false;
+
+  // Dynamic URC registration helpers
+  void registerURCs();
+  void unregisterURCs();
+  std::vector<String> registeredURCPatterns;
+
+  // Per-URC callbacks
+  void onRegChanged(const String &urc);
+  void onOpenResult(const String &urc);
+  void onClosed(const String &urc);
+  void onTcpRecv(const String &urc);
+  void onSslRecv(const String &urc);
+  void onReadData(const String &urc);
+  void onMqttRecv(const String &urc);
+  void onMqttStat(const String &urc);
+
+ public:
+  UrcState URCState;
+  AtomicMqttQueue *mqttQueueSub = nullptr;
+  ModemSIMCard sim;
+
+  ModemBackend() = default;
+  virtual ~ModemBackend() = 0;
+
+  virtual bool init(Stream &stream, AsyncATHandler &atHandler, GSMTransport &transport);
+  virtual bool setEchoOff();
+  virtual bool enableVerboseErrors();
+  virtual bool checkModemModel();
+  virtual bool checkTimezone();
+  virtual bool checkSIMReady();
+  virtual bool disalbeSleepMode();
+  virtual bool gprsConnect(const char *apn, const char *user = nullptr, const char *pass = nullptr);
+  virtual bool gprsDisconnect();
+  virtual String getSimCCID();
+  virtual String getIMEI();
+  virtual String getIMSI();
+  virtual String getOperator();
+  virtual String getIPAddress();
+  virtual bool connect(const char *host, uint16_t port);
+  virtual bool stop();
+  virtual bool connectSecure(const char *host, uint16_t port);
+  virtual bool connectSecure(const char *host, uint16_t port, const char *caCertPath);
+  virtual bool stopSecure();
+  virtual bool setSIMSlot(SimSlot slot);
+
+  virtual bool uploadUFSFile(
+      const char *path, const uint8_t *data, size_t size, uint32_t timeoutMs = 120000);
+  virtual bool setCACertificate(const char *ufsPath, const char *ssl_cidx);
+  virtual bool findUFSFile(
+      const char *pattern, String *outName = nullptr, size_t *outSize = nullptr);
+
+  // Helpers for GPRS connection
+  virtual void disableConnections();
+  virtual bool setPDPContext(const char *apn);
+  virtual bool activatePDPContext();
+  virtual bool isGPRSSAttached();
+  virtual bool checkNetworkContext();
+  virtual bool activatePDP();
+  virtual bool attachGPRS();
+};
+
+// Provide definition for pure-virtual destructor
+inline ModemBackend::~ModemBackend() {};

--- a/src/modules/Modem/SIMCard/SIM.h
+++ b/src/modules/Modem/SIMCard/SIM.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+#include <AsyncATHandler.h>
+
+#include "SIM.settings.h"
+
+class SIMCard {
+ public:
+  SIMCard() = default;
+  explicit SIMCard(AsyncATHandler &handler);
+
+  void init(AsyncATHandler &handler);
+  SimDetConfig getDetection();
+  SimStatus getStatus();
+  bool setStatusReport(bool enable);
+
+  SimSlot getCurrentSlot();
+  bool setSlot(SimSlot slot);
+
+ private:
+  AsyncATHandler *at{nullptr};
+  SimSlot currentSlot{SimSlot::UNKNOWN};
+};

--- a/src/modules/Modem/SIMCard/SIM.settings.h
+++ b/src/modules/Modem/SIMCard/SIM.settings.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <stdint.h>
+
+template <typename E>
+constexpr auto u8(E e) {
+  return static_cast<uint8_t>(e);
+}
+
+// =========================================================
+// SIM Detection Configuration ( +QSIMDET )
+// =========================================================
+
+struct SimDetConfig {
+  // Enable or disable (U)SIM card detection
+  enum class CardDetection : uint8_t {
+    DISABLE = 0,
+    ENABLE = 1,
+  };
+
+  enum class InsertLevel : uint8_t {
+    LOW_LEVEL = 0,
+    HIGH_LEVEL = 1,
+  };
+  CardDetection cardDetection{CardDetection::DISABLE};
+  InsertLevel insertLevel{InsertLevel::LOW_LEVEL};
+};
+
+// =========================================================
+// SIM Status Reporting ( +QSIMSTAT )
+// =========================================================
+
+struct SimStatus {
+  // If it is enabled, when (U)SIM card is removed or inserted,
+  // the URC +QSIMSTAT: <enable>,<insertedstatus> will be reported
+  enum class ReportState : uint8_t {
+    DISABLE = 0,
+    ENABLE = 1,
+  };
+
+  enum class InsertStatus : uint8_t {
+    REMOVED = 0,
+    INSERTED = 1,
+    UNKNOWN = 2,
+  };
+
+  ReportState enable{ReportState::DISABLE};
+  InsertStatus inserted{InsertStatus::UNKNOWN};
+};
+
+// =========================================================
+// SIM Slot Selection ( +QDSIM )
+// =========================================================
+
+enum class SimSlot : uint8_t {
+  UNKNOWN = 255,
+  SLOT_1 = 0,
+  SLOT_2 = 1,
+};


### PR DESCRIPTION
Closes #36

Introduce a unified Modem frontend that selects the correct backend (EG915 or SIM7080) in the constructor. Both drivers now extend ModemBackend, which defines the shared interface. Generic SIM enums and structs were consolidated. This refactor removes model-specific logic from higher layers and makes adding new modem drivers straightforward.